### PR TITLE
sync input before exec so the exec'd process doesn't miss buffered input

### DIFF
--- a/src/Encode.cc
+++ b/src/Encode.cc
@@ -37,6 +37,7 @@
         // clang-format on
     default:
         wait(nullptr);
+        std::cin.sync();
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         execl("/tmp/phase2", "/tmp/phase2", nullptr);
     }


### PR DESCRIPTION
Closes #2 